### PR TITLE
Check for errors before dereferencing id

### DIFF
--- a/users/commands.go
+++ b/users/commands.go
@@ -72,6 +72,10 @@ func (c *createUserCommand) Execute() error {
 	} else {
 		id, err = getUserGuid(createUserResponse["id"])
 	}
+	
+	if err != nil {
+	   return fmt.Errorf("Failed to find user id in createuser response: %v", err)
+	}
 
 	c.user.GUID = *id
 


### PR DESCRIPTION
If an error is returned id = nil so dereferencing (c.user.GUID = *id) panics.